### PR TITLE
Add initial FastAPI REST API

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,96 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from pydantic import BaseModel
+import os
+import tempfile
+from typing import Any, Dict, List
+
+from src.factory import AutoMeetAIFactory
+from src.models.transcription_result import TranscriptionResult, Utterance
+from src.exceptions import AutoMeetAIError
+from src.utils.logging import configure_logger, get_logger
+
+configure_logger()
+logger = get_logger(__name__)
+
+app = FastAPI(title="AutoMeetAI API")
+
+# Initialize AutoMeetAI using the factory
+factory = AutoMeetAIFactory()
+automeetai = factory.create()
+
+
+def _transcription_to_dict(transcription: TranscriptionResult) -> Dict[str, Any]:
+    """Convert a TranscriptionResult into a dictionary."""
+    return {
+        "text": transcription.text,
+        "utterances": [
+            {
+                "speaker": u.speaker,
+                "text": u.text,
+                "start": u.start,
+                "end": u.end,
+            }
+            for u in transcription.utterances
+        ],
+    }
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
+@app.post("/transcriptions")
+async def transcribe(file: UploadFile = File(...)) -> Dict[str, Any]:
+    """Process a video file and return its transcription."""
+    temp_path = None
+    try:
+        suffix = os.path.splitext(file.filename)[1] or ".mp4"
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            tmp.write(await file.read())
+            temp_path = tmp.name
+
+        transcription = automeetai.process_video(video_file=temp_path)
+        if not transcription:
+            raise HTTPException(status_code=500, detail="Transcription failed")
+        return _transcription_to_dict(transcription)
+    except AutoMeetAIError as exc:
+        logger.error(f"Error processing transcription: {exc}")
+        message = getattr(exc, "user_friendly_message", str(exc))
+        raise HTTPException(status_code=400, detail=message) from exc
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                logger.warning(f"Failed to remove temporary file {temp_path}")
+
+
+class AnalysisRequest(BaseModel):
+    """Request body for the analysis endpoint."""
+
+    text: str
+    system_prompt: str = "Você é um assistente de IA."
+    user_prompt: str = "Analise a transcrição a seguir:\n{transcription}"
+
+
+@app.post("/analysis")
+def analyze(request: AnalysisRequest) -> Dict[str, Any]:
+    """Analyze a transcription text using the AutoMeetAI services."""
+    transcription = TranscriptionResult(
+        utterances=[], text=request.text, audio_file="input.mp3"
+    )
+    try:
+        result = automeetai.analyze_transcription(
+            transcription=transcription,
+            system_prompt=request.system_prompt,
+            user_prompt_template=request.user_prompt,
+        )
+        if result is None:
+            raise HTTPException(status_code=500, detail="Analysis failed")
+        return {"analysis": result}
+    except AutoMeetAIError as exc:
+        logger.error(f"Error processing analysis: {exc}")
+        message = getattr(exc, "user_friendly_message", str(exc))
+        raise HTTPException(status_code=400, detail=message) from exc

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,7 @@ smmap>=5.0
 # --- Tratamento de imagens ---
 # Pillow precisa estar <10 por causa da restrição do Streamlit
 pillow>=9.5,<10
+
+# --- REST API ---
+fastapi>=0.111
+uvicorn>=0.29

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+from fastapi.testclient import TestClient
+
+# Allow importing the project root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import api  # noqa: E402
+
+
+class TestAPI(unittest.TestCase):
+    """Tests for the REST API."""
+
+    def setUp(self) -> None:
+        """Patch the AutoMeetAI instance used by the API."""
+        self.mock_app = MagicMock()
+        api.automeetai = self.mock_app
+        self.client = TestClient(api.app)
+
+    def test_health_endpoint(self):
+        """Ensure the health endpoint returns status ok."""
+        response = self.client.get("/health")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
+    def test_transcriptions_endpoint(self):
+        """Verify that the transcription endpoint processes files."""
+        from src.models.transcription_result import TranscriptionResult, Utterance
+
+        transcription = TranscriptionResult(
+            utterances=[Utterance(speaker="1", text="hello")],
+            text="hello",
+            audio_file="file.mp3",
+        )
+        self.mock_app.process_video.return_value = transcription
+
+        response = self.client.post(
+            "/transcriptions",
+            files={"file": ("test.mp4", b"data", "video/mp4")},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["text"], "hello")
+        self.mock_app.process_video.assert_called_once()
+
+    def test_analysis_endpoint(self):
+        """Verify that the analysis endpoint returns data."""
+        self.mock_app.analyze_transcription.return_value = "summary"
+
+        response = self.client.post(
+            "/analysis",
+            json={"text": "hello", "system_prompt": "sys", "user_prompt": "user {transcription}"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"analysis": "summary"})
+        self.mock_app.analyze_transcription.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add initial FastAPI REST API
- test REST endpoints using FastAPI's TestClient
- add FastAPI and uvicorn dependencies

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'moviepy')*

------
https://chatgpt.com/codex/tasks/task_e_683f88378e84832eadb19e6777b1f329