### PR TITLE
Add REST API documentation and fix property tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,29 @@ analysis = app.analyze_transcription(
 )
 ```
 
+### REST API
+
+You can also interact with AutoMeetAI through a simple REST API built with
+FastAPI. After installing the dependencies, run:
+
+```bash
+uvicorn api:app --reload
+```
+
+This will start a server on `http://localhost:8000` exposing the following
+endpoints:
+
+- `GET /health` – basic health check
+- `POST /transcriptions` – upload a video file and get its transcription
+- `POST /analysis` – analyze a transcription text
+
+The `/transcriptions` endpoint accepts optional query parameters to control the
+transcription process:
+
+- `speaker_labels` – whether to enable speaker diarization (default `true`)
+- `speakers_expected` – expected number of speakers (default `2`)
+- `language_code` – ISO code of the audio language (default `pt`)
+
 ## Extending the Application
 
 The modular architecture makes it easy to extend the application:

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -675,3 +675,32 @@ Obtém a implementação para um ponto de extensão.
 
 **Retorna:**
 - A implementação para o ponto de extensão, ou None se não suportado
+
+## REST API
+
+O AutoMeetAI também disponibiliza uma API REST simples implementada com
+[FastAPI](https://fastapi.tiangolo.com/). Essa API permite processar arquivos de
+vídeo remotamente e solicitar análises de transcrições.
+
+### Endpoints
+
+| Método | Caminho            | Descrição                                   |
+|-------:|--------------------|---------------------------------------------|
+| `GET`  | `/health`          | Verifica se o serviço está no ar            |
+| `POST` | `/transcriptions`  | Envia um vídeo e retorna a transcrição. Aceita parâmetros `speaker_labels`, `speakers_expected` e `language_code`. |
+| `POST` | `/analysis`        | Analisa um texto de transcrição e retorna o resultado |
+
+### Exemplo de uso
+
+```bash
+curl http://localhost:8000/health
+
+curl -X POST "http://localhost:8000/transcriptions?speaker_labels=false&speakers_expected=3&language_code=en" \
+     -F "file=@reuniao.mp4" -H "accept: application/json"
+
+curl -X POST http://localhost:8000/analysis \
+     -H "Content-Type: application/json" \
+     -d '{"text": "Olá mundo"}'
+```
+
+Consulte `api.py` para ver a implementação completa da API.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,10 +39,19 @@ class TestAPI(unittest.TestCase):
         response = self.client.post(
             "/transcriptions",
             files={"file": ("test.mp4", b"data", "video/mp4")},
+            params={
+                "speaker_labels": "false",
+                "speakers_expected": "3",
+                "language_code": "en",
+            },
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["text"], "hello")
         self.mock_app.process_video.assert_called_once()
+        cfg = self.mock_app.process_video.call_args.kwargs.get("transcription_config")
+        self.assertEqual(cfg["speaker_labels"], False)
+        self.assertEqual(cfg["speakers_expected"], 3)
+        self.assertEqual(cfg["language_code"], "en")
 
     def test_analysis_endpoint(self):
         """Verify that the analysis endpoint returns data."""

--- a/tests/utils/test_file_utils_properties.py
+++ b/tests/utils/test_file_utils_properties.py
@@ -29,6 +29,11 @@ except ImportError:
             return func
         return decorator
 
+    def settings(*args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
     # Create a dummy strategy class that implements common methods
     class DummyStrategy:
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- document FastAPI REST API usage in README and main docs
- clarify REST endpoints in api_documentation.md
- avoid NameError when Hypothesis isn't installed in property tests
- expose transcription options in REST API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fa6b803b8832e9add644321f8a6c0