### PR TITLE
Add API auth and GraphQL endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,11 @@ analysis = app.analyze_transcription(
 ### REST API
 
 You can also interact with AutoMeetAI through a simple REST API built with
-FastAPI. After installing the dependencies, run:
+FastAPI. The API requires an authentication token provided via the
+`AUTOMEETAI_API_AUTH_TOKEN` environment variable. Clients must send this token in
+the `X-API-Key` header when calling protected endpoints.
+
+After installing the dependencies, run:
 
 ```bash
 uvicorn api:app --reload
@@ -110,6 +114,7 @@ endpoints:
 - `GET /health` – basic health check
 - `POST /transcriptions` – upload a video file and get its transcription
 - `POST /analysis` – analyze a transcription text
+- `POST /graphql` – GraphQL endpoint with a playground
 
 
 The `/transcriptions` endpoint accepts optional query parameters to control the

--- a/api.py
+++ b/api.py
@@ -1,4 +1,6 @@
-from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi import FastAPI, UploadFile, File, HTTPException, Depends, Header, Request
+from starlette_graphene3 import GraphQLApp, make_playground_handler
+import graphene
 from pydantic import BaseModel
 import os
 import tempfile
@@ -13,6 +15,18 @@ configure_logger()
 logger = get_logger(__name__)
 
 app = FastAPI(title="AutoMeetAI API")
+
+# API authentication token from environment
+API_AUTH_TOKEN = os.environ.get("AUTOMEETAI_API_AUTH_TOKEN")
+
+
+def require_api_key(x_api_key: str = Header(None)) -> None:
+    """Validate the API key provided in the request header."""
+    if not API_AUTH_TOKEN:
+        logger.error("API authentication token is not configured.")
+        raise HTTPException(status_code=500, detail="API authentication not configured")
+    if x_api_key != API_AUTH_TOKEN:
+        raise HTTPException(status_code=401, detail="Invalid API key")
 
 # Initialize AutoMeetAI using the factory
 factory = AutoMeetAIFactory()
@@ -41,7 +55,7 @@ def health() -> Dict[str, str]:
     return {"status": "ok"}
 
 
-@app.post("/transcriptions")
+@app.post("/transcriptions", dependencies=[Depends(require_api_key)])
 async def transcribe(
     file: UploadFile = File(...),
     speaker_labels: bool = True,
@@ -91,7 +105,7 @@ class AnalysisRequest(BaseModel):
     user_prompt: str = "Analise a transcrição a seguir:\n{transcription}"
 
 
-@app.post("/analysis")
+@app.post("/analysis", dependencies=[Depends(require_api_key)])
 def analyze(request: AnalysisRequest) -> Dict[str, Any]:
     """Analyze a transcription text using the AutoMeetAI services."""
     transcription = TranscriptionResult(
@@ -110,3 +124,50 @@ def analyze(request: AnalysisRequest) -> Dict[str, Any]:
         logger.error(f"Error processing analysis: {exc}")
         message = getattr(exc, "user_friendly_message", str(exc))
         raise HTTPException(status_code=400, detail=message) from exc
+
+
+class Query(graphene.ObjectType):
+    """GraphQL query definitions."""
+
+    health = graphene.String()
+
+    def resolve_health(self, info):
+        return "ok"
+
+
+class Mutations(graphene.ObjectType):
+    """GraphQL mutations."""
+
+    analyze = graphene.Field(
+        graphene.String,
+        text=graphene.String(required=True),
+        system_prompt=graphene.String(default_value="Você é um assistente de IA."),
+        user_prompt=graphene.String(default_value="Analise a transcrição a seguir:\n{transcription}"),
+    )
+
+    def resolve_analyze(self, info, text: str, system_prompt: str, user_prompt: str):
+        transcription = TranscriptionResult(utterances=[], text=text, audio_file="input.mp3")
+        try:
+            return automeetai.analyze_transcription(
+                transcription=transcription,
+                system_prompt=system_prompt,
+                user_prompt_template=user_prompt,
+            )
+        except AutoMeetAIError as exc:
+            message = getattr(exc, "user_friendly_message", str(exc))
+            raise Exception(message)
+
+
+schema = graphene.Schema(query=Query, mutation=Mutations)
+graphql_app = GraphQLApp(schema=schema, on_get=make_playground_handler())
+
+
+@app.api_route("/graphql", methods=["GET", "POST"])
+async def graphql_endpoint(request: Request, x_api_key: str = Header(None)):
+    """GraphQL endpoint with API key validation."""
+    require_api_key(x_api_key)
+    if request.method == "GET":
+        response = await graphql_app._get_on_get(request)
+    else:
+        response = await graphql_app._handle_http_request(request)
+    return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,8 @@ fastapi>=0.111
 uvicorn>=0.29
 
 python-multipart>=0.0.9     # ← adicionado
+graphene>=3.4               # GraphQL support
+starlette-graphene3>=0.6    # GraphQL integration with FastAPI
 
 # --- Configuração baseada em variáveis ---
 pydantic-settings>=2.2       # ← adicionado

--- a/src/config/default_config.py
+++ b/src/config/default_config.py
@@ -12,6 +12,10 @@ ASSEMBLYAI_API_KEY = None
 OPENAI_API_KEY = None
 OPENAI_MODEL = "gpt-4o-2024-08-06"
 
+# REST API authentication
+# Must be set via environment variable AUTOMEETAI_API_AUTH_TOKEN
+API_AUTH_TOKEN = None
+
 # Whisper API configuration
 # Uses the same API key as OpenAI (AUTOMEETAI_OPENAI_API_KEY)
 WHISPER_MODEL = "whisper-1"

--- a/src/config/env_config_provider.py
+++ b/src/config/env_config_provider.py
@@ -28,6 +28,7 @@ class EnvConfigProvider(ConfigProvider):
             # API keys
             "assemblyai_api_key": lambda key: ConfigValidator.validate_api_key(key, "AssemblyAI"),
             "openai_api_key": lambda key: ConfigValidator.validate_api_key(key, "OpenAI"),
+            "api_auth_token": lambda key: ConfigValidator.validate_api_key(key, "API Auth"),
 
             # Rate limits
             "assemblyai_rate_limit": lambda rate: ConfigValidator.validate_rate_limit(rate, "AssemblyAI"),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,9 @@ import unittest
 from unittest.mock import MagicMock
 from fastapi.testclient import TestClient
 
+# Configure API authentication for tests
+os.environ["AUTOMEETAI_API_AUTH_TOKEN"] = "testtoken"
+
 # Allow importing the project root
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -44,6 +47,7 @@ class TestAPI(unittest.TestCase):
                 "speakers_expected": "3",
                 "language_code": "en",
             },
+            headers={"X-API-Key": "testtoken"},
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["text"], "hello")
@@ -60,10 +64,38 @@ class TestAPI(unittest.TestCase):
         response = self.client.post(
             "/analysis",
             json={"text": "hello", "system_prompt": "sys", "user_prompt": "user {transcription}"},
+            headers={"X-API-Key": "testtoken"},
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"analysis": "summary"})
         self.mock_app.analyze_transcription.assert_called_once()
+
+    def test_missing_api_key(self):
+        """Requests without the API key should fail."""
+        response = self.client.post("/analysis", json={"text": "hello"})
+        self.assertEqual(response.status_code, 401)
+
+    def test_graphql_health(self):
+        """Query health over GraphQL."""
+        response = self.client.post(
+            "/graphql",
+            json={"query": "{ health }"},
+            headers={"X-API-Key": "testtoken"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["data"]["health"], "ok")
+
+    def test_graphql_analyze(self):
+        """Mutation analyze over GraphQL."""
+        self.mock_app.analyze_transcription.return_value = "summary"
+        mutation = "mutation { analyze(text: \"hello\") }"
+        response = self.client.post(
+            "/graphql",
+            json={"query": mutation},
+            headers={"X-API-Key": "testtoken"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["data"]["analyze"], "summary")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- secure REST API endpoints with API key header
- expose new GraphQL endpoint
- document authentication & GraphQL usage in README
- support new `API_AUTH_TOKEN` config value
- test GraphQL endpoint and auth logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404a326a54832eadbb5f1e3cc6ed41