### PR TITLE
Add IETF language code support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,8 @@ As configurações são definidas em `src/config/default_config.py` e podem ser 
 | `DEFAULT_SPEAKER_LABELS` | `bool` | `True` | Se deve identificar falantes diferentes na transcrição. | `AUTOMEETAI_DEFAULT_SPEAKER_LABELS` |
 | `DEFAULT_SPEAKERS_EXPECTED` | `int` | `2` | Número esperado de falantes na transcrição. | `AUTOMEETAI_DEFAULT_SPEAKERS_EXPECTED` |
 
+O valor `language_code` segue o padrão IETF, permitindo códigos como `en-US`, `pt-BR` ou `es-ES`. Os códigos atualmente suportados são: `pt`, `pt-BR`, `pt-PT`, `en`, `en-US`, `en-GB`, `es`, `es-ES`, `es-MX`, `fr`, `fr-FR`, `de`, `de-DE`, `it`, `it-IT`, `nl`, `ja`, `ja-JP`, `ko`, `ko-KR`, `zh`, `zh-CN`, `zh-TW` e `ru`.
+
 ## Configuração de Arquivos
 
 | Opção | Tipo | Padrão | Descrição | Variável de Ambiente |

--- a/src/config/config_validator.py
+++ b/src/config/config_validator.py
@@ -4,9 +4,20 @@ Utilitário para validação de valores de configuração.
 from typing import Any, Dict, Optional, List, Union, Callable
 import os
 from src.utils.logging import get_logger
+import re
 
 # Initialize logger for this module
 logger = get_logger(__name__)
+
+# Supported IETF language codes (language or language-region)
+_SUPPORTED_LANGUAGE_CODES = {
+    "pt", "pt-br", "pt-pt", "en", "en-us", "en-gb", "es", "es-es", "es-mx",
+    "fr", "fr-fr", "de", "de-de", "it", "it-it", "nl", "ja", "ja-jp", "ko",
+    "ko-kr", "zh", "zh-cn", "zh-tw", "ru",
+}
+
+# Pattern to validate language codes like "xx" or "xx-yy"
+_LANGUAGE_CODE_PATTERN = re.compile(r"^[a-zA-Z]{2}(?:-[a-zA-Z]{2})?$")
 
 
 class ConfigValidator:
@@ -123,13 +134,19 @@ class ConfigValidator:
         if not isinstance(code, str):
             raise ValueError("Language code must be a string.")
 
-        # Lista de códigos de idioma válidos (simplificada)
-        valid_codes = ["pt", "en", "es", "fr", "de", "it", "nl", "ja", "ko", "zh", "ru"]
-        
-        if code.lower() not in valid_codes:
-            logger.warning(f"Language code '{code}' may not be supported. Valid codes include: {', '.join(valid_codes)}")
+        # Validate format "xx" or "xx-yy"
+        if not _LANGUAGE_CODE_PATTERN.match(code):
+            raise ValueError("Language code must be in format 'xx' or 'xx-yy'.")
 
-        return code
+        normalized = code.lower()
+
+        if normalized not in _SUPPORTED_LANGUAGE_CODES:
+            logger.warning(
+                f"Language code '{code}' may not be officially supported. Valid codes include: "
+                f"{', '.join(sorted(_SUPPORTED_LANGUAGE_CODES))}"
+            )
+
+        return normalized
 
     @staticmethod
     def validate_speakers_expected(count: int) -> int:

--- a/tests/config/test_config_validator.py
+++ b/tests/config/test_config_validator.py
@@ -1,0 +1,25 @@
+import unittest
+
+from src.config.config_validator import ConfigValidator
+
+class TestConfigValidatorLanguage(unittest.TestCase):
+    def test_accepts_supported_language_codes(self):
+        valid_codes = [
+            "pt", "pt-BR", "pt-PT", "en", "en-US", "en-GB", "es", "es-ES",
+            "es-MX", "fr", "fr-FR", "de", "de-DE", "it", "it-IT", "nl",
+            "ja", "ja-JP", "ko", "ko-KR", "zh", "zh-CN", "zh-TW", "ru",
+        ]
+        for code in valid_codes:
+            with self.subTest(code=code):
+                normalized = ConfigValidator.validate_language_code(code)
+                self.assertEqual(normalized, code.lower())
+
+    def test_invalid_format_raises_error(self):
+        invalid_codes = ["english", "123", "en_US", "e", "en-us-extra"]
+        for code in invalid_codes:
+            with self.subTest(code=code):
+                with self.assertRaises(ValueError):
+                    ConfigValidator.validate_language_code(code)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow language codes like `en-US` and `pt-BR` in ConfigValidator
- document supported language codes and IETF format
- test language code validation

## Testing
- `pytest tests/config/test_config_validator.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684099398b00832eb8438b1fa8b0a387