### PR TITLE
Add Docker support and documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+tests/
+docs/
+.git/
+cache/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.tmp
+*.log
+*.swp
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY src ./src
+COPY app.py api.py stream_transcribe.py .
+
+# Create and use a non-root user
+RUN useradd -m appuser
+USER appuser
+
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ automeetai/
    - Set environment variable `AUTOMEETAI_ASSEMBLYAI_API_KEY` with your AssemblyAI API key
    - Set environment variable `AUTOMEETAI_OPENAI_API_KEY` with your OpenAI API key (optional)
 
+## Docker
+
+A `Dockerfile` is provided to build a container image. The accompanying
+`.dockerignore` excludes `tests/`, `docs/`, `.git/`, `cache/` and temporary
+files so the build context remains small. The image installs dependencies from
+`requirements.txt` and creates a non-root user called `appuser` for safer
+execution.
+
+Build the image with:
+
+```bash
+docker build -t automeetai .
+```
+
 ## Usage
 
 ### Command Line


### PR DESCRIPTION
## Summary
- add `.dockerignore`
- add `Dockerfile` that installs requirements and uses a non-root user
- document Docker build instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e7993fe8832ea21417272e373463