### PR TITLE
Add AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Instruções para a Junie AI
+
+Este repositório utiliza o arquivo **AGENTS.md** para fornecer diretrizes à Junie AI durante a criação de PRs.
+
+## Regras Gerais
+
+- **Sempre execute os testes** antes de criar um PR. Use:
+  ```bash
+  python tests/run_tests_with_coverage.py
+  ```
+  Ajuste as opções conforme necessário (por exemplo `--html` ou `--min-coverage`).
+- Siga as práticas descritas em `docs/developer_guide.md` e `.junie/guidelines.md`:
+  - Use Python 3.8+ e preferencialmente um ambiente virtual.
+  - Inclua *type hints* e docstrings no estilo Google, em português.
+  - Respeite os princípios SOLID e utilize injeção de dependência.
+- Não inclua chaves de API ou dados sensíveis no repositório.
+- Documente qualquer nova configuração ou funcionalidade na pasta `docs/`.
+
+Consulte a documentação em `docs/` para detalhes sobre arquitetura, estilo de código e procedimentos de contribuição.


### PR DESCRIPTION
## Summary
- add AGENTS.md with guidelines for Junie AI

## Testing
- `python tests/run_tests_with_coverage.py` *(fails: ModuleNotFoundError: No module named 'moviepy')*

------
https://chatgpt.com/codex/tasks/task_e_6840ec0183e4832e9c23e3eb61df29b6