### PR TITLE
Implement microservices architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,18 +111,26 @@ analysis = app.analyze_transcription(
 
 ### REST API
 
-You can also interact with AutoMeetAI through a simple REST API built with
-FastAPI. The API requires an authentication token provided via the
-`AUTOMEETAI_API_AUTH_TOKEN` environment variable. Clients must send this token in
-the `X-API-Key` header when calling protected endpoints.
+You can interact with AutoMeetAI through REST APIs built with FastAPI. An
+authentication token is provided via the
+`AUTOMEETAI_API_AUTH_TOKEN` environment variable and must be sent in the
+`X-API-Key` header when calling protected endpoints.
 
-After installing the dependencies, run:
+Previously a single monolithic API was provided. The project now offers two
+independent microservices:
+
+1. **Transcription Service** – handles file uploads and returns the
+   transcription result.
+2. **Analysis Service** – performs analysis on previously generated
+   transcriptions.
+
+For development you can still run the original API with:
 
 ```bash
 uvicorn api:app --reload
 ```
 
-This will start a server on `http://localhost:8000` exposing the following
+This starts a server on `http://localhost:8000` exposing the following
 endpoints:
 
 - `GET /health` – basic health check
@@ -142,13 +150,18 @@ transcription process:
 
 Docker makes it easy to run AutoMeetAI without installing Python or dependencies.
 
-Build the image and start the API with Docker Compose:
+Build the images and start the microservices with Docker Compose:
 
 ```bash
 docker compose up --build
 ```
 
-Then access the API at `http://localhost:8000`. Set the `AUTOMEETAI_API_AUTH_TOKEN` environment variable in `docker-compose.yml` to secure your deployment.
+The services will be available at:
+
+- `http://localhost:8001` – Transcription Service
+- `http://localhost:8002` – Analysis Service
+
+Set the `AUTOMEETAI_API_AUTH_TOKEN` environment variable in `docker-compose.yml` to secure your deployment.
 
 
 ## Extending the Application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,16 @@
 version: '3.9'
 services:
-  automeetai:
+  transcription-service:
     build: .
+    command: uvicorn src.microservices.transcription_service:app --host 0.0.0.0 --port 8000
     ports:
-      - "8000:8000"
+      - "8001:8000"
+    environment:
+      - AUTOMEETAI_API_AUTH_TOKEN=changeme
+  analysis-service:
+    build: .
+    command: uvicorn src.microservices.analysis_service:app --host 0.0.0.0 --port 8000
+    ports:
+      - "8002:8000"
     environment:
       - AUTOMEETAI_API_AUTH_TOKEN=changeme

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -13,6 +13,7 @@ Este guia fornece instruções detalhadas para desenvolvedores que desejam esten
 7. [Criando um Plugin](#criando-um-plugin)
 8. [Estendendo o CLI](#estendendo-o-cli)
 9. [Melhores Práticas](#melhores-práticas)
+10. [Arquitetura de Microsserviços](#arquitetura-de-microsservicos)
 
 ## Arquitetura do Sistema
 
@@ -741,3 +742,7 @@ Ao estender o AutoMeetAI, siga estas melhores práticas:
 10. **Atualize a documentação**: Atualize a documentação da API e os exemplos de uso quando adicionar novas funcionalidades.
 
 Seguindo este guia, você poderá estender o AutoMeetAI de forma eficaz e manter a qualidade do código.
+
+## Arquitetura de Microsservicos
+
+Consulte o documento [Arquitetura de Microsserviços](microservices_architecture.md) para entender como o projeto foi dividido em serviços independentes.

--- a/docs/microservices_architecture.md
+++ b/docs/microservices_architecture.md
@@ -1,0 +1,27 @@
+# Arquitetura de Microsserviços
+
+Este documento descreve a nova abordagem de microsserviços adotada pelo AutoMeetAI.
+
+## Visão Geral
+
+A aplicação foi dividida em dois microsserviços principais para melhorar a escalabilidade e a separação de responsabilidades:
+
+- **Transcription Service**: responsável por receber arquivos de vídeo e retornar a transcrição processada.
+- **Analysis Service**: realiza a análise de transcrições utilizando serviços de geração de texto.
+
+Cada microsserviço é exposto através de uma API separada com autenticação por chave. Ambos utilizam o `AutoMeetAIFactory` para construir suas dependências.
+
+## Como Executar
+
+Utilize o `docker-compose.yml` para iniciar os serviços:
+
+```bash
+docker compose up --build
+```
+
+Os serviços ficam disponíveis em:
+
+- `http://localhost:8001` – Transcription Service
+- `http://localhost:8002` – Analysis Service
+
+Configure a variável `AUTOMEETAI_API_AUTH_TOKEN` para proteger as APIs.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -80,7 +80,7 @@ This document contains a prioritized list of tasks for improving the AutoMeetAI 
 
 ### Architecture Improvements
 
-- [ ] 1. Implement a microservices architecture for better scalability and separation of concerns
+- [x] 1. Implement a microservices architecture for better scalability and separation of concerns
 - [ ] 2. Add a message queue system for asynchronous processing of large batches
 - [ ] 3. Implement a proper database for storing transcription results instead of file-based storage
 - [ ] 4. Create a service discovery mechanism for dynamically loading service implementations

--- a/src/microservices/analysis_service.py
+++ b/src/microservices/analysis_service.py
@@ -1,0 +1,70 @@
+from fastapi import FastAPI, HTTPException, Header, Depends
+from pydantic import BaseModel
+from typing import Any, Dict
+
+from src.config.env_config_provider import EnvConfigProvider
+from src.config.config_validator import ConfigValidator
+from src.factory import AutoMeetAIFactory
+from src.models.transcription_result import TranscriptionResult
+from src.exceptions import AutoMeetAIError
+from src.utils.logging import configure_logger, get_logger
+
+configure_logger()
+logger = get_logger(__name__)
+
+app = FastAPI(title="AutoMeetAI Analysis Service")
+
+_config = EnvConfigProvider()
+API_AUTH_TOKEN = _config.get("api_auth_token")
+if API_AUTH_TOKEN:
+    try:
+        API_AUTH_TOKEN = ConfigValidator.validate_api_key(API_AUTH_TOKEN, "API Auth")
+    except ValueError as exc:
+        logger.error(f"Invalid API authentication token: {exc}")
+        API_AUTH_TOKEN = None
+
+
+def require_api_key(x_api_key: str = Header(None)) -> None:
+    """Validates the API key provided by the client."""
+    if not API_AUTH_TOKEN:
+        logger.error("API authentication token is not configured.")
+        raise HTTPException(status_code=500, detail="API authentication not configured")
+    if x_api_key != API_AUTH_TOKEN:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+factory = AutoMeetAIFactory()
+automeetai = factory.create()
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
+class AnalysisRequest(BaseModel):
+    """Request body for the analysis endpoint."""
+
+    text: str
+    system_prompt: str = "Você é um assistente de IA."
+    user_prompt: str = "Analise a transcrição a seguir:\n{transcription}"
+
+
+@app.post("/analysis", dependencies=[Depends(require_api_key)])
+def analyze(request: AnalysisRequest) -> Dict[str, Any]:
+    """Analyze a transcription text and return the result."""
+    transcription = TranscriptionResult(utterances=[], text=request.text, audio_file="input.mp3")
+    try:
+        result = automeetai.analyze_transcription(
+            transcription=transcription,
+            system_prompt=request.system_prompt,
+            user_prompt_template=request.user_prompt,
+        )
+        if result is None:
+            raise HTTPException(status_code=500, detail="Analysis failed")
+        return {"analysis": result}
+    except AutoMeetAIError as exc:
+        logger.error(f"Error processing analysis: {exc}")
+        message = getattr(exc, "user_friendly_message", str(exc))
+        raise HTTPException(status_code=400, detail=message) from exc

--- a/src/microservices/transcription_service.py
+++ b/src/microservices/transcription_service.py
@@ -1,0 +1,95 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException, Header, Depends
+import os
+import tempfile
+from typing import Any, Dict
+
+from src.config.env_config_provider import EnvConfigProvider
+from src.config.config_validator import ConfigValidator
+from src.factory import AutoMeetAIFactory
+from src.models.transcription_result import TranscriptionResult
+from src.exceptions import AutoMeetAIError
+from src.utils.logging import configure_logger, get_logger
+
+configure_logger()
+logger = get_logger(__name__)
+
+app = FastAPI(title="AutoMeetAI Transcription Service")
+
+# Authentication token from environment
+_config = EnvConfigProvider()
+API_AUTH_TOKEN = _config.get("api_auth_token")
+if API_AUTH_TOKEN:
+    try:
+        API_AUTH_TOKEN = ConfigValidator.validate_api_key(API_AUTH_TOKEN, "API Auth")
+    except ValueError as exc:
+        logger.error(f"Invalid API authentication token: {exc}")
+        API_AUTH_TOKEN = None
+
+
+
+def require_api_key(x_api_key: str = Header(None)) -> None:
+    """Validates the API key provided by the client."""
+    if not API_AUTH_TOKEN:
+        logger.error("API authentication token is not configured.")
+        raise HTTPException(status_code=500, detail="API authentication not configured")
+    if x_api_key != API_AUTH_TOKEN:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+factory = AutoMeetAIFactory()
+automeetai = factory.create()
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
+@app.post("/transcriptions", dependencies=[Depends(require_api_key)])
+async def transcribe(
+    file: UploadFile = File(...),
+    speaker_labels: bool = True,
+    speakers_expected: int = 2,
+    language_code: str = "pt",
+) -> Dict[str, Any]:
+    """Process a video file and return its transcription."""
+    temp_path = None
+    try:
+        suffix = os.path.splitext(file.filename)[1] or ".mp4"
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            tmp.write(await file.read())
+            temp_path = tmp.name
+
+        transcription = automeetai.process_video(
+            video_file=temp_path,
+            transcription_config={
+                "speaker_labels": speaker_labels,
+                "speakers_expected": speakers_expected,
+                "language_code": language_code,
+            },
+        )
+        if not transcription:
+            raise HTTPException(status_code=500, detail="Transcription failed")
+        return {
+            "text": transcription.text,
+            "utterances": [
+                {
+                    "speaker": u.speaker,
+                    "text": u.text,
+                    "start": u.start,
+                    "end": u.end,
+                }
+                for u in transcription.utterances
+            ],
+        }
+    except AutoMeetAIError as exc:
+        logger.error(f"Error processing transcription: {exc}")
+        message = getattr(exc, "user_friendly_message", str(exc))
+        raise HTTPException(status_code=400, detail=message) from exc
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                logger.warning(f"Failed to remove temporary file {temp_path}")

--- a/tests/test_microservices.py
+++ b/tests/test_microservices.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+from fastapi.testclient import TestClient
+
+# Configure API authentication for tests
+os.environ["AUTOMEETAI_API_AUTH_TOKEN"] = "testtoken123"
+
+# Allow importing the project root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.microservices import transcription_service, analysis_service  # noqa: E402
+
+
+class TestTranscriptionService(unittest.TestCase):
+    """Tests for the transcription microservice."""
+
+    def setUp(self) -> None:
+        """Patch the AutoMeetAI instance used by the service."""
+        self.mock_app = MagicMock()
+        transcription_service.automeetai = self.mock_app
+        self.client = TestClient(transcription_service.app)
+
+    def test_health(self):
+        response = self.client.get("/health")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
+    def test_transcribe(self):
+        from src.models.transcription_result import TranscriptionResult, Utterance
+
+        transcription = TranscriptionResult(
+            utterances=[Utterance(speaker="1", text="hello")],
+            text="hello",
+            audio_file="file.mp3",
+        )
+        self.mock_app.process_video.return_value = transcription
+
+        response = self.client.post(
+            "/transcriptions",
+            files={"file": ("test.mp4", b"data", "video/mp4")},
+            params={"speaker_labels": "false"},
+            headers={"X-API-Key": "testtoken123"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["text"], "hello")
+        self.mock_app.process_video.assert_called_once()
+
+
+class TestAnalysisService(unittest.TestCase):
+    """Tests for the analysis microservice."""
+
+    def setUp(self) -> None:
+        self.mock_app = MagicMock()
+        analysis_service.automeetai = self.mock_app
+        self.client = TestClient(analysis_service.app)
+
+    def test_health(self):
+        response = self.client.get("/health")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
+    def test_analyze(self):
+        self.mock_app.analyze_transcription.return_value = "summary"
+        response = self.client.post(
+            "/analysis",
+            json={"text": "hello"},
+            headers={"X-API-Key": "testtoken123"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"analysis": "summary"})
+        self.mock_app.analyze_transcription.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- split API into Transcription Service and Analysis Service
- document new services and update developer guide
- adjust docker-compose to run both microservices
- add tests for microservices endpoints

## Testing
- `python tests/run_tests_with_coverage.py`
- `python tests/run_tests_with_coverage.py --min-coverage 0`


------
https://chatgpt.com/codex/tasks/task_e_6840ef01cbb8832ea2bd3837c009fb6f